### PR TITLE
[BUGFIX] Correctly register event listeners to stop workers

### DIFF
--- a/Classes/DependencyInjection/MessengerConfigPass.php
+++ b/Classes/DependencyInjection/MessengerConfigPass.php
@@ -192,6 +192,11 @@ class MessengerConfigPass implements CompilerPassInterface
         $container->getDefinition('messenger.retry_strategy_locator')
             ->replaceArgument(0, $transportRetryReferences);
 
+
+        $failureTransportsByTransportNameServiceLocator = ServiceLocatorTagPass::register($container, $failureTransportReferencesByTransportName);
+        $container->getDefinition('messenger.failure.send_failed_message_to_failure_transport_listener')
+            ->replaceArgument(0, $failureTransportsByTransportNameServiceLocator);
+
         if (\count($failureTransports) > 0) {
             $container->getDefinition('console.command.messenger_failed_messages_retry')
                 ->replaceArgument(0, $config['failure_transport']);
@@ -199,10 +204,6 @@ class MessengerConfigPass implements CompilerPassInterface
                 ->replaceArgument(0, $config['failure_transport']);
             $container->getDefinition('console.command.messenger_failed_messages_remove')
                 ->replaceArgument(0, $config['failure_transport']);
-
-            $failureTransportsByTransportNameServiceLocator = ServiceLocatorTagPass::register($container, $failureTransportReferencesByTransportName);
-            $container->getDefinition('messenger.failure.send_failed_message_to_failure_transport_listener')
-                ->replaceArgument(0, $failureTransportsByTransportNameServiceLocator);
         } else {
             /*
              * TODO: Find better solution. The removing will break scheduler

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -7,6 +7,7 @@ namespace TYPO3\CMS\Core;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface as EventDispatcherInterfaceComponentAlias;
 use Symfony\Component\Messenger\DependencyInjection\MessengerPass;
@@ -24,7 +25,7 @@ return static function (ContainerConfigurator $container, ContainerBuilder $cont
         ->alias(EventDispatcherInterfaceComponentAlias::class, 'event_dispatcher')
         ->alias(EventDispatcherInterface::class, 'event_dispatcher');
 
-
+    $containerBuilder->addCompilerPass(new RegisterListenersPass(), PassConfig::TYPE_BEFORE_REMOVING);
     $containerBuilder->addCompilerPass(new MessengerBaseConfigPass(),PassConfig::TYPE_BEFORE_OPTIMIZATION, 900);
     $containerBuilder->addCompilerPass(new MessengerConfigPass());
     $containerBuilder->addCompilerPass(new MessengerPass());


### PR DESCRIPTION
* add `RegisterListenersPass`
* always define `$failureSenders` in `SendFailedMessageToFailureTransportListener`

Fixes #3 